### PR TITLE
autonetkit-cisco-webui should not only install for dev

### DIFF
--- a/virl/ank/init.sls
+++ b/virl/ank/init.sls
@@ -251,8 +251,6 @@ autonetkit_cisco:
 
 {% endif %}
 
-{% if venv == 'qa' or venv == 'dev' %}
-
 autonetkit_cisco_webui:
   pip.installed:
     {% if ank_ver_fixed %}
@@ -278,6 +276,8 @@ autonetkit_cisco_webui:
       - rm -f /etc/init.d/ank-webserver
     - onchanges:
       - pip: autonetkit_cisco_webui
+
+{% if venv == 'qa' or venv == 'dev' %}
 
 textfsm:
   pip.installed:


### PR DESCRIPTION
I'm not sure if this is the correct fix, but autonetkit-cisco-webui is included
in the vV204 distribution media, but is not installed with the current salt
states.
