### PR TITLE
Add flask dependency and ifb module loading

### DIFF
--- a/virl/std/init.sls
+++ b/virl/std/init.sls
@@ -135,6 +135,15 @@ std_prereq_webmux:
     - target: /etc/init.d/virl-uwm
     - mode: 0755
 
+ifb modprobe:
+  file.append:
+    - name: /etc/modules
+    - text: ifb numifbs=32
+    - unless: grep ifb /etc/modules
+  cmd.run:
+    - name: modprobe ifb numifbs=32
+    - unless: grep "^ifb" /proc/modules
+
 std uwm port replace:
   file.replace:
       - name: /var/www/html/index.html

--- a/virl/std/init.sls
+++ b/virl/std/init.sls
@@ -180,6 +180,7 @@ std_prereq:
       - Flask_Login == 0.2.11
       - Flask_RESTful >= 0.3.2
       - Flask_WTF >= 0.11
+      - Flask_Breadcrumbs >= 0.3.0
       - itsdangerous >= 0.24
       - Jinja2 >= 2.7.3
       - lxml <= 3.3.3


### PR DESCRIPTION
Two patches - first adds a new dependency for recent UWM changes, second sets up the ifb networking module with 32 interfaces (should be enough for everyone).
