### PR TITLE
Updated and improved Docker registry installation state

### DIFF
--- a/virl/docker-engine.sls
+++ b/virl/docker-engine.sls
@@ -1,17 +1,18 @@
 ## Install docker with registry running in container and docker-py for docker API
 {% set registry_ip = salt['pillar.get']('virl:l2_address2', salt['grains.get']('l2_address2', '172.16.2.254/xx' )).split('/')[0] %}
 {% set registry_port = salt['pillar.get']('virl:docker_registry_port', salt['grains.get']('docker_registry_port', '19397' )) %}
-# Version specific setting (specif. versions of docker (1.7.1), docker-py (1.4.0) and registry (2.0.1) due to used version of CoreOS 1.7.1)
-{% set docker_version = '1.7.1' %}
-{% set docker_file = 'docker-engine-1.7.1.deb' %}
-{% set docker_hash = 'f9a045be56c6bf6e3aa0f75b41c4f2fb' %}
-{% set docker_py_file = 'docker_py-1.4.0-py2-none-any.whl' %}
-{% set docker_py_ver = 'docker-py==1.4.0' %}
-{% set registry_version = '2.0.1' %}
-{% set registry_file = 'registry-2.0.1.tar' %}
-{% set registry_file_hash = '70cf7524959cabfbb0f21ead98ecfa24' %}
+{% set docker_version = '1.9.1-0~trusty' %}
+{% set registry_version = '2.3.1' %}
+{% set registry_file = 'registry-2.3.1.tar' %}
+{% set registry_file_hash = '81fe4000d19021f6444c5e96704872d2' %}
 # If updating registry load registry manually into docker and get its Docker ID by issue $docker images
-{% set registry_docker_ID = 'f9684be4155a' %}
+{% set registry_docker_ID = '53773d8552f0' %}
+
+{% set download_proxy = salt['pillar.get']('virl:download_proxy', salt['grains.get']('download_proxy', '')) %}
+{% set download_no_proxy = salt['pillar.get']('virl:download_no_proxy', salt['grains.get']('download_no_proxy', '')) %}
+
+{% set proxy = salt['pillar.get']('virl:proxy', salt['grains.get']('proxy', False)) %}
+{% set http_proxy = salt['pillar.get']('virl:http_proxy', salt['grains.get']('http_proxy', 'https://proxy-wsa.esl.cisco.com:80/')) %}
 
 # Docker:
 
@@ -19,69 +20,141 @@ remove_wrong_docker:
   pkg.purged:
     - name: lxc-docker
 
-download_docker-engine:
+# this installs along docker-engine, using http repo instead
+# docker_repository_prereq:
+#   pkg.installed:
+#     - refresh: False
+#     - pkgs:
+#       - apt-transport-https
+#       - ca-certificates
+
+docker_repository:
   file.managed:
-    - name: /var/cache/apt/archives/{{ docker_file }}
-    - makedirs: True
-    - source:
-      - salt://virl/files/{{ docker_file }}
-    - source_hash: md5={{ docker_hash }}
+    - name: /etc/apt/sources.list.d/virl-docker.list
+    - mode: 0755
+    - contents: |
+        deb http://apt.dockerproject.org/repo ubuntu-trusty main
+    # - require:
+    #   - pkg: docker_repository_prereq
 
-install_docker-engine:
+docker_repository_key:
   cmd.run:
-    - name: dpkg -i /var/cache/apt/archives/{{ docker_file }}
-    - unless: dpkg -l docker-engine | grep '^ii.*{{ docker_version }}'
+    - names:
+      - apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 
-config_docker:
+docker_pin:
+  file.managed:
+    - name: /etc/apt/preferences.d/virl-docker
+    - mode: 0755
+    - contents: |
+        Package: docker-engine
+        Pin: version {{ docker_version }}
+        Pin-Priority: 1001
+    - required_in:
+      - pkg: docker_install
+
+docker_remove:
+  pkg.removed:
+    - name: docker-engine
+
+docker_install:
+  pkg.installed:
+    - refresh: True
+    - name: docker-engine
+    - require:
+      - file: docker_repository
+      - cmd: docker_repository_key
+      - file: docker_pin
+      - pkg: docker_remove
+
+docker_config-opts:
   file.replace:
     - name: /etc/default/docker
     - pattern: '^DOCKER_OPTS.*$'
     - repl: DOCKER_OPTS="--insecure-registry={{ registry_ip }}:{{ registry_port }}"
                ## Sometimes docker service does not working OK:
                # try play around with docker arg tlsverify=false
-    - flags: ['IGNORECASE']
+    - flags: ['IGNORECASE', 'MULTILINE']
     - append_if_not_found: True
     - require_in:
-      - module: restart_docker_service
+      - module: docker_restart
+docker_config-proxy:
+  file.replace:
+    - name: /etc/default/docker
+    - pattern: '^export http_proxy.*$'
+    - repl: export http_proxy={{ download_proxy }}
+    - flags: ['IGNORECASE', 'MULTILINE']
+    - append_if_not_found: True
+    - require_in:
+      - module: docker_restart
+docker_config-noproxy:
+  file.replace:
+    - name: /etc/default/docker
+    - pattern: '^export no_proxy.*$'
+    - repl: export no_proxy={{ registry_ip }},{{download_no_proxy}},$no_proxy
+    - flags: ['IGNORECASE', 'MULTILINE']
+    - append_if_not_found: True
+    - require_in:
+      - module: docker_restart
 
-restart_docker_service:
+docker_restart:
   module.run:
     - name: service.restart
     - m_name: docker
+    - require:
+      - file: docker_config-opts
+      - file: docker_config-proxy
+      - file: docker_config-noproxy
 
 # docker-py:
 
 docker-py:
-  file.managed:
-    - name: /usr/share/python-wheels/{{ docker_py_file }}
-    - makedirs: True
-    - source: salt://virl/files/{{ docker_py_file }}
-    - unless: pip freeze | grep {{ docker_py_ver }}
-  cmd.run:
-    - name: pip install /usr/share/python-wheels/{{ docker_py_file }}
-    - unless: pip freeze | grep {{ docker_py_ver }}
+  pip.installed:
+    - name: docker-py
+    - upgrade: True
+    {% if proxy == true %}
+    - proxy: {{ http_proxy }}
+    {% endif %}
 
 # add registry into docker:
 
-load_registry:
+registry_remove:
+  cmd.script:
+    - source: salt://virl/files/remove_docker_registry.sh
+    - env:
+      REGISTRY_ID: {{ registry_docker_ID }}
+      REGISTRY_IP: {{ registry_ip }}
+      REGISTRY_PORT: {{ registry_port }}
+    - require:
+      - pkg: docker_install
+      - module: docker_restart
+
+registry_load:
   # state docker.loaded is buggy -> file.managed and cmd.run
   file.managed:
     - name: /usr/share/{{ registry_file }}
     - source: salt://virl/files/{{ registry_file }}
     - source_hash: {{ registry_file_hash }}
-    - unless: docker images | grep registry\ *{{ registry_version }}
+    - unless: docker images -q | grep {{ registry_docker_ID }}
   cmd.run:
     - names:
       - docker load -i /usr/share/{{ registry_file }} 
-      - docker tag {{ registry_docker_ID }} registry:{{ registry_version }}
-    - unless: docker images | grep registry\ *{{ registry_version }}
+    - unless: docker images -q | grep '{{ registry_docker_ID }}'
 
-run_registry:
+registry_tag:
+  cmd.run:
+    - names:
+      - docker tag {{ registry_docker_ID }} registry:{{ registry_version }}
+    - unless: docker images | grep '^registry *{{ registry_version }} *{{ registry_docker_ID }}'
+    - require:
+      - cmd: registry_load
+
+registry_run:
   # dockerio.running replaced by cmd.run due to API problems of dockerio/docker-py used versions
   cmd.run:
     - names:
       - docker run -d -p {{ registry_ip }}:{{ registry_port }}:5000 -e REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY=/var/lib/registry -v /var/local/virl/docker:/var/lib/registry --restart=always registry:{{ registry_version }}
     - require:
-      - cmd: load_registry
-    - unless: docker ps | grep "{{ registry_ip }}:{{ registry_port }}->5000/tcp"
+      - cmd: registry_tag
+    # - unless: docker ps | grep "{{ registry_ip }}:{{ registry_port }}->5000/tcp"
 

--- a/virl/files/remove_docker_registry.sh
+++ b/virl/files/remove_docker_registry.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+stop_image() {
+    IMAGE_NAME=$1
+    CONTAINER_IDS=`docker ps -a | grep "$IMAGE_NAME" | awk '{ print $1 }'`
+    if [ -n "$CONTAINER_IDS" ]; then
+        for CONTAINER_ID in $CONTAINER_IDS; do
+            docker stop $CONTAINER_ID || true
+            docker rm $CONTAINER_ID
+        done
+    fi
+    docker rmi $IMAGE_NAME
+}
+
+# remove registry:TAG images
+RUNNING_REGISTRY=`docker ps -a | egrep -o 'registry:[^ ]+'`
+if [ -n "$RUNNING_REGISTRY" ]; then
+    for IMAGE_NAME in $RUNNING_REGISTRY; do
+        stop_image $IMAGE_NAME
+    done
+fi
+# remove everything on our IP:PORT
+RUNNING_REGISTRY=`docker ps | grep "$REGISTRY_IP:$REGISTRY_PORT->5000/tcp" | awk '{ printf("%s:%s", $1, $2) }'`
+if [ -n "$RUNNING_REGISTRY" ]; then
+    for IMAGE_NAME in $RUNNING_REGISTRY; do
+        stop_image $IMAGE_NAME
+    done
+fi
+# remove everything with our image ID
+REGISTRY_NAMES=`docker images | grep $REGISTRY_ID | awk '{ printf("%s:%s\n", $1, $2) }'`
+if [ -n "$REGISTRY_NAMES" ]; then
+    for IMAGE_NAME in $REGISTRY_NAMES; do
+        stop_image $IMAGE_NAME
+    done
+fi


### PR DESCRIPTION
The state is not picked up automatically just yet. We do wonder whether docker over coreos enablement should be a flag for virl.ini.

The coreos image is on beta /srv/salt2/images/salt/coreos-899-13-0.qcow2.
