### PR TITLE
Fixes failure to change SNAT settings

### DIFF
--- a/openstack/neutron/create-basic.sls
+++ b/openstack/neutron/create-basic.sls
@@ -94,6 +94,11 @@ create snat subnet:
     - require:
       - cmd: create snat net
 
+create ext-net router-gateway:
+  cmd.run:
+    - name: neutron --os-tenant-name admin --os-username admin --os-password {{ ospassword }} --os-auth-url=http://{{ controllerip }}:5000/v2.0 router-list -c id -f csv | grep -o '[a-fA-F0-9-]\{36\}' | xargs -IX -n 1 neutron --os-tenant-name admin --os-username admin --os-password {{ ospassword }} --os-auth-url=http://{{ controllerip }}:5000/v2.0 router-gateway-set X ext-net
+    - onlyif: neutron --os-tenant-name admin --os-username admin --os-password {{ ospassword }} --os-auth-url=http://{{ controllerip }}:5000/v2.0 subnet-show ext-net
+
 create quota update:
   cmd.run:
     - name: neutron --os-tenant-name admin --os-username admin --os-password {{ ospassword }} --os-auth-url=http://127.0.1.1:5000/v2.0 quota-update --router -1

--- a/openstack/neutron/delete-basic.sls
+++ b/openstack/neutron/delete-basic.sls
@@ -1,10 +1,19 @@
 {% set ospassword = salt['pillar.get']('virl:password', salt['grains.get']('password', 'password')) %}
 {% set controllerip = salt['pillar.get']('virl:internalnet_controller_ip',salt['grains.get']('internalnet_controller_ip', '172.16.10.250')) %}
 
+clear ext-net router-gateway:
+  cmd.run:
+    - name: neutron --os-tenant-name admin --os-username admin --os-password {{ ospassword }} --os-auth-url=http://{{ controllerip }}:5000/v2.0 router-list -c id -f csv | grep -o '[a-fA-F0-9-]\{36\}' | xargs -n 1 neutron --os-tenant-name admin --os-username admin --os-password {{ ospassword }} --os-auth-url=http://{{ controllerip }}:5000/v2.0 router-gateway-clear
+    - onlyif: neutron --os-tenant-name admin --os-username admin --os-password {{ ospassword }} --os-auth-url=http://{{ controllerip }}:5000/v2.0 subnet-show ext-net
+
 {% for each in ['flat','flat1','ext-net'] %}
 delete {{ each }}:
-  module.run:
-    - name: neutron.delete_subnet
-    - subnet: {{ each }}
+#  module.run:
+#    - name: neutron.delete_subnet
+#    - subnet: {{ each }}
+#    - onlyif: neutron --os-tenant-name admin --os-username admin --os-password {{ ospassword }} --os-auth-url=http://{{ controllerip }}:5000/v2.0 subnet-show {{ each }}
+# this seems to work flawlessly, above fails mysteriously
+  cmd.run:
+    - name: neutron --os-tenant-name admin --os-username admin --os-password {{ ospassword }} --os-auth-url=http://{{ controllerip }}:5000/v2.0 subnet-delete {{ each }}
     - onlyif: neutron --os-tenant-name admin --os-username admin --os-password {{ ospassword }} --os-auth-url=http://{{ controllerip }}:5000/v2.0 subnet-show {{ each }}
 {% endfor %}

--- a/openstack/setup.sls
+++ b/openstack/setup.sls
@@ -8,6 +8,7 @@ include:
   - openstack.keystone.apache2
   - openstack.nova.keystone
   - openstack.neutron.changes
+  - openstack.neutron.delete-basic
   - openstack.neutron.create-basic
   - openstack.cinder.create
 {% endif %}


### PR DESCRIPTION
Failure seems to be due to another project that is not deleted during rehost (unlike guest) and it prevents the change.  Adding gateway operation and delete-basic recreates SNAT properly with new settings.

neutron.subnet_delete fails for unknown reasons (somehow missing service type when making call: Module function neutron.delete_subnet threw an exception. Exception: publicURL endpoint for _BLANK_ service not found) while neutron client call always works.
