### PR TITLE
Terraform destroy & save fix

### DIFF
--- a/virl/terraform/destroy.sls
+++ b/virl/terraform/destroy.sls
@@ -16,3 +16,4 @@ http_proxy:
 terminate:
   cmd.run:
     - name: terraform destroy -no-color -force {{ path }} || terraform destroy -no-color -force {{ path }}
+    - cwd: {{ path }}

--- a/virl/terraform/save.sls
+++ b/virl/terraform/save.sls
@@ -24,14 +24,16 @@ create sshdir for root:
     - user: root
     - group: staff
     - mode: 0700
-    - name: mkdir -p ~/.ssh
+    # hardcoded homedir for use with sudo
+    - name: mkdir -p /root/.ssh
 
 copy ssh key pem:
   file.copy:
     - user: root
     - group: staff
     - mode: 0600
-    - name: ~/.ssh/id_rsa
+    # hardcoded homedir for use with sudo
+    - name: /root/.ssh/id_rsa
     - source: ~virl/.ssh/id_rsa
     - force: true
 
@@ -40,7 +42,8 @@ copy ssh key pub:
     - user: root
     - group: staff
     - mode: 0600
-    - name: ~/.ssh/id_rsa.pub
+    # hardcoded homedir for use with sudo
+    - name: /root/.ssh/id_rsa.pub
     - source: ~virl/.ssh/id_rsa.pub
     - force: true
 


### PR DESCRIPTION
Fixed terraform destroy operation.

Hardcoded root homedir for key synchronization so it can be used with sudo.  Current file.copy code seems to be logically sound only the message is confusing (skipped after hash comparison, not based on file existence).  There was an interesting related bug though: https://github.com/saltstack/salt/commit/0ff4366e91f3b3e3011fe60dc2225c14ac70ff23
