### PR TITLE
Ulimit raise to 16384 open file handles

### DIFF
--- a/virl/std/tap-counter.sls
+++ b/virl/std/tap-counter.sls
@@ -43,7 +43,8 @@ virl_tap_counter_conf:
         TC_POLL_INTERVAL="1"
         # How long will each redis record last before expiry
         TC_TTL="600"
-	ULIMIT=16384
+	# Limit for open filehandles. One interface accounts for 4 filehandles
+	ULIMIT="16384"
 
 
 {% if controller == true %}

--- a/virl/std/tap-counter.sls
+++ b/virl/std/tap-counter.sls
@@ -43,6 +43,7 @@ virl_tap_counter_conf:
         TC_POLL_INTERVAL="1"
         # How long will each redis record last before expiry
         TC_TTL="600"
+	ULIMIT=16384
 
 
 {% if controller == true %}


### PR DESCRIPTION
virl-tap-counter script would give up after reaching 256 interfaces. not anymore
