### PR TITLE
Create docker config file if it does not exist for some reason

### DIFF
--- a/virl/docker/config.sls
+++ b/virl/docker/config.sls
@@ -5,6 +5,12 @@
 {% set download_proxy = salt['pillar.get']('virl:download_proxy', salt['grains.get']('download_proxy', '')) %}
 {% set download_no_proxy = salt['pillar.get']('virl:download_no_proxy', salt['grains.get']('download_no_proxy', '')) %}
 
+docker_config:
+  file.managed:
+    - name: /etc/default/docker
+    - mode: 0644
+    - unless: test -e /etc/default/docker
+
 docker_config-opts:
   file.replace:
     - name: /etc/default/docker


### PR DESCRIPTION
Joel witnessed missing /etc/default/docker file, just making sure it is present.
