### PR TITLE
Fix dockerng issues on fresh install

### DIFF
--- a/virl/docker/config.sls
+++ b/virl/docker/config.sls
@@ -1,4 +1,3 @@
-## Install docker with registry running in container and docker-py for docker API
 {% set registry_ip = salt['pillar.get']('virl:l2_address2', salt['grains.get']('l2_address2', '172.16.2.254/xx' )).split('/')[0] %}
 {% set registry_port = salt['pillar.get']('virl:docker_registry_port', salt['grains.get']('docker_registry_port', '19397' )) %}
 

--- a/virl/docker/init.sls
+++ b/virl/docker/init.sls
@@ -6,6 +6,7 @@
 {% set registry_version = '2.4.0' %}
 {% set registry_file = 'registry-2.4.0.tar' %}
 {% set registry_file_hash = '0c79a98a8a2954c3bc04388be22ec0f5' %}
+{% set tap_counter_file_hash = 'a4eae90640eb3fd9983b4b93ad809c63' %}
 # If updating registry load registry manually into docker and get its Docker ID by issue $docker images
 {% set registry_docker_ID = '0f29f840cdef' %}
 {% set tapcounter_docker_ID = 'fd89e345206b' %}
@@ -13,69 +14,29 @@
 {% set download_proxy = salt['pillar.get']('virl:download_proxy', salt['grains.get']('download_proxy', '')) %}
 {% set download_no_proxy = salt['pillar.get']('virl:download_no_proxy', salt['grains.get']('download_no_proxy', '')) %}
 
-
-{% from "virl.jinja" import virl with context %}
-
-docker registry settings:
-  cmd.run:
-    - names:
-      - crudini --set /etc/virl/common.cfg host docker_registry_ip {{ registry_ip }}
-      - crudini --set /etc/virl/common.cfg host docker_registry_port {{ registry_port }}
-
-# Docker:
-
-remove_wrong_docker:
-  pkg.purged:
-    - name: lxc-docker
-
-docker_repository:
-  file.managed:
-    - name: /etc/apt/sources.list.d/virl-docker.list
-    - mode: 0755
-    - contents: |
-        deb http://apt.dockerproject.org/repo ubuntu-trusty main
-
-docker_repository_key:
-  cmd.run:
-    - names:
-      - apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-
-docker_pin:
-  file.managed:
-    - name: /etc/apt/preferences.d/virl-docker
-    - mode: 0755
-    - contents: |
-        Package: docker-engine
-        Pin: version {{ docker_version }}
-        Pin-Priority: 1001
-    - required_in:
-      - pkg: docker_install
-
-docker_remove:
-  pkg.removed:
-    - name: docker-engine
-
-docker_install:
-  pkg.installed:
-    - refresh: True
-    - name: docker-engine
-    - require:
-      - file: docker_repository
-      - cmd: docker_repository_key
-      - file: docker_pin
-      - pkg: docker_remove
+{% set proxy = salt['pillar.get']('virl:proxy', salt['grains.get']('proxy', False)) %}
+{% set http_proxy = salt['pillar.get']('virl:http_proxy', salt['grains.get']('http_proxy', 'https://proxy-wsa.esl.cisco.com:80/')) %}
 
 include:
-  - virl.docker.config
+  - .install
+  - .config
 
 # docker-py:
 
 docker-py:
   pip.installed:
     - name: docker-py
-    {% if virl.proxy  %}
-    - proxy: {{ virl.http_proxy }}
+    {% if proxy == true %}
+    - proxy: {{ http_proxy }}
     {% endif %}
+
+# restart to make dockerng work
+docker-py docker_restart:
+  module.run:
+    - name: service.restart
+    - m_name: docker
+    - require:
+      - pip: docker-py
 
 # add registry into docker:
 
@@ -121,12 +82,44 @@ registry_run:
     # - unless: docker ps | grep "{{ registry_ip }}:{{ registry_port }}->5000/tcp"
 
 # Docker tap-counter
+tap_counter_remove:
+  cmd.run:
+    - names:
+      - docker rmi {{ registry_ip }}:{{ registry_port }}/virl-tap-counter:latest || true
+      - docker rmi virl-tap-counter:latest || true
+      - docker rmi {{ tapcounter_docker_ID }} || true
+    - require:
+      - pkg: docker_install
+      - module: docker_restart
+
+tap_counter_load:
+  # state docker.loaded is buggy -> file.managed and cmd.run
+  file.managed:
+    - name: /var/cache/virl/docker/docker-tap-counter.tar
+    - makedirs: True
+    - source: salt://images/salt/docker-tap-counter.tar
+    - source_hash: {{ tap_counter_file_hash }}
+    - unless: docker images -q | grep {{ tapcounter_docker_ID }}
+  cmd.run:
+    - names:
+      - docker load -i /var/cache/virl/docker/docker-tap-counter.tar
+    - unless: docker images -q | grep '{{ tapcounter_docker_ID }}'
+
+tap_counter_tag:
+  cmd.run:
+    - names:
+      - docker tag {{ tapcounter_docker_ID }} virl-tap-counter:latest
+    - unless: docker images | grep '^virl-tap-counter *latest *{{ tapcounter_docker_ID }}'
+    - require:
+      - cmd: tap_counter_load
+
 virl-tap-counter:latest:
   # this remembers previously used registry IP:port and restores it,
   # don't include them or it will cause issues when IP/port changes
-  dockerng.image_present:
-    - load: salt://images/salt/docker-tap-counter.tar
-    - force: True
+# removed altogether, it dockerng is not available until later if docker-py was not installed
+#  dockerng.image_present:
+#    - load: salt://images/salt/docker-tap-counter.tar
+#    - force: True
   cmd.run:
     - names:
       - docker tag -f {{ tapcounter_docker_ID }} {{ registry_ip }}:{{ registry_port }}/virl-tap-counter:latest
@@ -140,3 +133,6 @@ virl_tap_counter_clean:
       - docker rmi {{ registry_ip }}:{{ registry_port }}/virl-tap-counter:latest
       - docker rmi virl-tap-counter:latest
       - docker rmi {{ tapcounter_docker_ID }} || true
+    - require:
+    #  - cmd: virl-tap-counter:latest
+       - cmd: tap_counter_tag

--- a/virl/docker/install.sls
+++ b/virl/docker/install.sls
@@ -1,0 +1,63 @@
+{% set registry_ip = salt['pillar.get']('virl:l2_address2', salt['grains.get']('l2_address2', '172.16.2.254/xx' )).split('/')[0] %}
+{% set registry_port = salt['pillar.get']('virl:docker_registry_port', salt['grains.get']('docker_registry_port', '19397' )) %}
+
+{% set docker_version = '1.9.1-0~trusty' %}
+
+docker registry settings:
+  cmd.run:
+    - names:
+      - crudini --set /etc/virl/common.cfg host docker_registry_ip {{ registry_ip }}
+      - crudini --set /etc/virl/common.cfg host docker_registry_port {{ registry_port }}
+
+# Docker:
+
+remove_wrong_docker:
+  pkg.purged:
+    - name: lxc-docker
+
+# this installs along docker-engine, using http repo instead
+# docker_repository_prereq:
+#   pkg.installed:
+#     - refresh: False
+#     - pkgs:
+#       - apt-transport-https
+#       - ca-certificates
+
+docker_repository:
+  file.managed:
+    - name: /etc/apt/sources.list.d/virl-docker.list
+    - mode: 0755
+    - contents: |
+        deb http://apt.dockerproject.org/repo ubuntu-trusty main
+    # - require:
+    #   - pkg: docker_repository_prereq
+
+docker_repository_key:
+  cmd.run:
+    - names:
+      - apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+
+docker_pin:
+  file.managed:
+    - name: /etc/apt/preferences.d/virl-docker
+    - mode: 0755
+    - contents: |
+        Package: docker-engine
+        Pin: version {{ docker_version }}
+        Pin-Priority: 1001
+    - required_in:
+      - pkg: docker_install
+
+docker_remove:
+  pkg.removed:
+    - name: docker-engine
+
+docker_install:
+  pkg.installed:
+    - refresh: True
+    - name: docker-engine
+    - require:
+      - file: docker_repository
+      - cmd: docker_repository_key
+      - file: docker_pin
+      - pkg: docker_remove


### PR DESCRIPTION
Rewritten tap-counter installation to avoid dockerng because it fails if docker-py was not available prior to executing this state (next run should be ok though).  This is state that works on Ubuntu 16.04 and also should avoid incomplete Docker installations for users.
