### PR TITLE
Drone 0.8-1

### DIFF
--- a/virl/routervms/lxc_ostinato.sls
+++ b/virl/routervms/lxc_ostinato.sls
@@ -10,7 +10,7 @@ lxc_ostinato:
   virl_core.lxc_image_present:
   - subtype: lxc-ostinato
   - version: standard
-  - release: 0.7.1-2build1
+  - release: 0.8-1
 
 {% else %}
 


### PR DESCRIPTION
Image lxc-ostinato-standard with drone 0.8-1
New lxc image is uploaded on virl-salt-beta at:
/srv/salt2/images/salt/lxc-ostinato-standard.tar.gz
