### PR TITLE
Fix nova config to explicitly use neutron networking

### DIFF
--- a/openstack/nova/files/mitaka.nova.conf
+++ b/openstack/nova/files/mitaka.nova.conf
@@ -29,6 +29,7 @@ api_paste_config=/etc/nova/api-paste.ini
 volumes_path=/var/lib/nova/volumes
 enabled_apis=osapi_compute,metadata
 
+use_neutron = True
 network_api_class = nova.network.neutronv2.api.API
 neutron_url = http://{{ salt['pillar.get']('virl:internalnet_controller_ip', salt['grains.get']('hostname', '172.16.10.250')) }}:9696
 neutron_auth_strategy = keystone


### PR DESCRIPTION
Prevent possible future breakage:

WARNING nova.network [-] Config mismatch. The network_api_class specifies nova.network.neutronv2.api.API, however use_neutron is not set to True. Using Neutron networking for now, however please set use_neutron to True in your configuration as network_api_class is deprecated and will be removed. 
