### PR TITLE
Fix hw_cdrom_bus property name

### DIFF
--- a/virl/routervms/asav.sls
+++ b/virl/routervms/asav.sls
@@ -18,7 +18,7 @@ asav:
     - disk_format: qcow2
     - copy_from: salt://images/salt/asav952-204.qcow2
     - property-config_disk_type: cdrom
-    - property-hw_cdrom_type: ide
+    - property-hw_cdrom_bus: ide
     - property-hw_disk_bus: ide
     - property-hw_vif_model: e1000
     - property-release: 9.5.2-204

--- a/virl/routervms/cml_iosv.sls
+++ b/virl/routervms/cml_iosv.sls
@@ -16,7 +16,7 @@ iosv:
     - disk_format: qcow2
     - copy_from: salt://images/salt/vios-adventerprisek9-m.cml.vmdk.SPA.155-3.M
     - property-config_disk_type: disk
-    - property-hw_cdrom_type: ide
+    - property-hw_cdrom_bus: ide
     - property-hw_disk_bus: virtio
     - property-hw_vif_model: e1000
     - property-release: 15.5.3.M

--- a/virl/routervms/coreos.sls
+++ b/virl/routervms/coreos.sls
@@ -15,7 +15,7 @@ coreos:
     - disk_format: qcow2
     - copy_from: salt://images/salt/coreos-899-13-0.qcow2
     - property-config_disk_type: cloud-init
-    - property-hw_cdrom_type: ide
+    - property-hw_cdrom_bus: ide
     - property-hw_disk_bus: ide
     - property-hw_vif_model: virtio
     - property-release: 899.13.0

--- a/virl/routervms/csr1000v.sls
+++ b/virl/routervms/csr1000v.sls
@@ -17,7 +17,7 @@ CSR1000v:
   - disk_format: qcow2
   - copy_from: salt://images/salt/{{ salt['pillar.get']('routervm_files:csr1000v')}}
   - property-config_disk_type: cdrom
-  - property-hw_cdrom_type: ide
+  - property-hw_cdrom_bus: ide
   - property-hw_disk_bus: virtio
   - property-hw_vif_model: virtio
   - property-release: {{ salt['pillar.get']('version:csr1000v')}}

--- a/virl/routervms/iosv.sls
+++ b/virl/routervms/iosv.sls
@@ -26,7 +26,7 @@ iosv:
     - protected: False
     - disk_format: qcow2
     - property-config_disk_type: disk
-    - property-hw_cdrom_type: ide
+    - property-hw_cdrom_bus: ide
     - property-hw_disk_bus: virtio
     - property-hw_vif_model: e1000
     - property-release: 15.6.2.T

--- a/virl/routervms/iosvl2.sls
+++ b/virl/routervms/iosvl2.sls
@@ -29,7 +29,7 @@ IOSvL2:
     - property-release: 15.2.4055
 {% endif %}
     - property-config_disk_type: disk
-    - property-hw_cdrom_type: ide
+    - property-hw_cdrom_bus: ide
     - property-hw_disk_bus: virtio
     - property-hw_vif_model: e1000
     - property-serial: 2

--- a/virl/routervms/iosxrv.sls
+++ b/virl/routervms/iosxrv.sls
@@ -19,7 +19,7 @@ iosxrv:
   - disk_format: qcow2
   - copy_from: salt://images/salt/{{ salt['pillar.get']('routervm_files:iosxrv')}}
   - property-config_disk_type: cdrom
-  - property-hw_cdrom_type: id
+  - property-hw_cdrom_bus: ide
   - property-hw_disk_bus: ide
   - property-hw_vif_model: virtio
   - property-release: {{ salt['pillar.get']('version:iosxrv')}}

--- a/virl/routervms/iosxrv9000.sls
+++ b/virl/routervms/iosxrv9000.sls
@@ -19,7 +19,7 @@ iosxrv 9000:
   - disk_format: qcow2
   - copy_from: salt://images/salt/{{ salt['pillar.get']('routervm_files:iosxr9000')}}
   - property-config_disk_type: cdrom
-  - property-hw_cdrom_type: id
+  - property-hw_cdrom_bus: ide
   - property-hw_disk_bus: virtio
   - property-hw_vif_model: virtio
   - property-release: {{ salt['pillar.get']('version:iosxr9000')}}

--- a/virl/routervms/nxosv.sls
+++ b/virl/routervms/nxosv.sls
@@ -19,7 +19,7 @@ NX-OSv:
   - disk_format: qcow2
   - copy_from: salt://images/salt/titanium-final.7.3.0.D1.1.qcow2
   - property-config_disk_type: cdrom
-  - property-hw_cdrom_type: ide
+  - property-hw_cdrom_bus: ide
   - property-hw_disk_bus: ide
   - property-hw_vif_model: e1000
   - property-release: 7.3.0.1

--- a/virl/routervms/vpagent.sls
+++ b/virl/routervms/vpagent.sls
@@ -19,7 +19,7 @@ vpagent:
     - disk_format: qcow2
     - copy_from: salt://images/salt/vios-tpgen_adventerprisek9-m.15.4.20140131.qcow2
     - property-config_disk_type: disk
-    - property-hw_cdrom_type: ide
+    - property-hw_cdrom_bus: ide
     - property-hw_disk_bus: virtio
     - property-hw_vif_model: e1000
     - property-release: 15.4

--- a/virl/routervms/xrodl.sls
+++ b/virl/routervms/xrodl.sls
@@ -12,7 +12,7 @@ iosxrv:
   - disk_format: qcow2
   - copy_from: salt://images/salt/iosxrv-5.3.2-11-i2ss.qcow2
   - property-config_disk_type: cdrom
-  - property-hw_cdrom_type: id
+  - property-hw_cdrom_bus: ide
   - property-hw_disk_bus: ide
   - property-hw_vif_model: virtio
   - property-release: 5.3.2


### PR DESCRIPTION
Note that the previous values were not used since the name wasn't correct. I only recall this ever being necessary for csr1000v. Interesting that nobody had an issue with that.
