### PR TITLE
Enable flooding

### DIFF
--- a/openstack/neutron/files/mitaka.neutron.conf
+++ b/openstack/neutron/files/mitaka.neutron.conf
@@ -121,7 +121,11 @@ auth_strategy = keystone
 # dhcp_agent_notification = True
 
 # native bridge flooding
-network_physical_ageing = {{ salt['pillar.get']('virl:neutron_bridge_flooding', salt['grains.get']('neutron_bridge_flooding', True )) }}
+{% if salt['pillar.get']('virl:neutron_bridge_flooding', salt['grains.get']('neutron_bridge_flooding', True )) %}
+network_bridge_ageing = 0
+# allow flooding on physical (flat) bridges as well (default False) 
+# network_physical_ageing = False
+{% endif %}
 
 # Enable or disable bulk create/update/delete operations
 allow_bulk = True

--- a/openstack/neutron/files/mitaka/neutron+agent+linux+bridge_lib.py
+++ b/openstack/neutron/files/mitaka/neutron+agent+linux+bridge_lib.py
@@ -137,7 +137,7 @@ class BridgeDevice(ip_lib.IPDevice):
         if ageing is None:
             return
         if physical and not physical_ageing:
-            ageing = 0
+            return
         try:
             self._tee(BRIDGE_AGEING_FS, ageing)
         except RuntimeError:


### PR DESCRIPTION
Fixed logic blunder that actually set flooding on flat bridges instead of preventing it.

Also fixed that the other setting of network_bridge_ageing should be set; the network_physical_ageing is there just to be able to also flood flat bridges if anyone really needs that.
