### PR TITLE
Fix lingering socat processes

### DIFF
--- a/common/xenial-bootstrap.sls
+++ b/common/xenial-bootstrap.sls
@@ -28,7 +28,7 @@ socat purge:
 socat 1.7.2.3:
  pkg.installed:
    - pkgs:
-      - socat < 1.7.2.4
+      - socat: 1.7.2.3-1
 
 disable upgrades:
  pkg.removed:

--- a/common/xenial-bootstrap.sls
+++ b/common/xenial-bootstrap.sls
@@ -20,6 +20,16 @@ qemu purge:
       - qemu-kvm
       - qemu-system-common
 
+# we need to use older version provided by trusty to avoid lingering socats
+socat purge:
+ pkg.removed:
+   - pkgs:
+     - socat
+socat 1.7.2.3:
+ pkg.installed:
+   - pkgs:
+      - socat < 1.7.2.4
+
 disable upgrades:
  pkg.removed:
    - pkgs:

--- a/common/xenial-bootstrap.sls
+++ b/common/xenial-bootstrap.sls
@@ -20,16 +20,6 @@ qemu purge:
       - qemu-kvm
       - qemu-system-common
 
-# we need to use older version provided by trusty to avoid lingering socats
-socat purge:
- pkg.removed:
-   - pkgs:
-     - socat
-socat 1.7.2.3:
- pkg.installed:
-   - pkgs:
-      - socat: 1.7.2.3-1
-
 disable upgrades:
  pkg.removed:
    - pkgs:

--- a/common/xenial-repo.sls
+++ b/common/xenial-repo.sls
@@ -3,7 +3,7 @@
   file.managed:
     - mode: 0644
     - contents:  |
-          deb http://us.archive.ubuntu.com/ubuntu/ trusty main restricted
-          deb http://us.archive.ubuntu.com/ubuntu/ trusty-updates main restricted
+          deb http://us.archive.ubuntu.com/ubuntu/ trusty main restricted universe
+          deb http://us.archive.ubuntu.com/ubuntu/ trusty-updates main restricted universe
 
 {% endif %}

--- a/virl/files/telnet_front
+++ b/virl/files/telnet_front
@@ -61,7 +61,8 @@ while running_parent && [ "$LOOPS" -ne 0 ]; do
     ##date
     ##echo "Running socat $PRIVATE:$PORT:$OUTSIDE (loops left $LOOPS)"
     LOOPS+=-1
-    socat $DEBUG -t $EOFRSTTIME -T $NODATATIME \
+    timeout --foreground --preserve-status 900 socat \
+         $DEBUG -t $EOFRSTTIME -T $NODATATIME \
         "TCP-LISTEN:$PORT,bind=$OUTSIDE,reuseaddr,$LISTENOPTS" \
         "TCP:$PRIVATE:$PORT,connect-timeout=$CONNECTIME" \
 

--- a/virl/files/telnet_front.aa
+++ b/virl/files/telnet_front.aa
@@ -12,6 +12,7 @@
   /usr/bin/telnet_front rmix,
   /usr/bin/socat rmix,
   /bin/sleep rmix,
+  /usr/bin/timeout rmix,
 
   @{PROC}/[0-9]*/cmdline r,
   @{PROC}/@{pid}/net/dev r,


### PR DESCRIPTION
socats are not exiting after nodes are destroyed, revert to trusty socat version as temporary fix
