### PR TITLE
Use new mitaka option to limit node retries

### DIFF
--- a/openstack/nova/files/mitaka.nova.conf
+++ b/openstack/nova/files/mitaka.nova.conf
@@ -54,6 +54,10 @@ novncproxy_base_url = http://127.0.1.1:{{ salt['pillar.get']('virl:vnc_port', sa
 
 scheduler_default_filters= {{  salt['pillar.get']('virl:nova_filter', salt['grains.get']('nova_filter', 'AllHostsFilter' )) }}
 
+{% if not virl.cluster %}
+scheduler_max_attempts = 1
+{% endif%}
+
 quota_instances=100
 quota_cores=30
 quota_injected_files = 100


### PR DESCRIPTION
On non-cluster VIRL all attempts fail with same error, cut it short and do not retry.
