### PR TITLE
Fixed syntax error

### DIFF
--- a/virl/std/prereq.sls
+++ b/virl/std/prereq.sls
@@ -85,5 +85,5 @@ std_prereq:
       - WTForms >= 2.0.2
       - WTForms-JSON >= 0.2.10
       - tornado >= 3.2.2
-      - require:
-        - pkg: 'std prereq pkgs'
+    - require:
+      - pkg: 'std prereq pkgs'


### PR DESCRIPTION
I found this in jenkins job:

==> default: Warnings:
==> default: 'pkg' is an invalid keyword argument for 'pip.installed'. If you were trying to pass additional data to be used in a template context, please populate 'context' with 'key: value' pairs. Your approach will work until Salt Carbon is out. Please update your state files.  Name: require - Function: pip.installed - Result: Changed
