### PR TITLE
Prevent nova quotas interfering with large individual node config

### DIFF
--- a/openstack/nova/files/compute.nova.conf
+++ b/openstack/nova/files/compute.nova.conf
@@ -56,6 +56,7 @@ scheduler_default_filters= {{  salt['pillar.get']('virl:nova_filter', salt['grai
 quota_instances=100
 quota_cores=30
 quota_injected_files = 100
+quota_injected_file_content_bytes = 800000
 
 vif_plugging_timeout = 0
 

--- a/openstack/nova/files/kilo.nova.conf
+++ b/openstack/nova/files/kilo.nova.conf
@@ -55,6 +55,7 @@ scheduler_default_filters= {{  salt['pillar.get']('virl:nova_filter', salt['grai
 quota_instances=100
 quota_cores=30
 quota_injected_files = 100
+quota_injected_file_content_bytes = 800000
 
 vif_plugging_timeout = 0
 

--- a/openstack/nova/files/mitaka.nova.conf
+++ b/openstack/nova/files/mitaka.nova.conf
@@ -61,6 +61,7 @@ scheduler_max_attempts = 1
 quota_instances=100
 quota_cores=30
 quota_injected_files = 100
+quota_injected_file_content_bytes = 800000
 
 vif_plugging_timeout = 0
 


### PR DESCRIPTION
The number is made larger than what was attempted. Not that the CSR was happy about 14k lines of config, but nova shouldn't interfere.