### PR TITLE
Mitaka upstream

### DIFF
--- a/openstack/keystone/endpoint.sls
+++ b/openstack/keystone/endpoint.sls
@@ -30,7 +30,7 @@ keystone endpoint:
 neutron endpoint:
   keystone.endpoint_present:
     - name: neutron
-    - publicurl: http://{{ public_ip }}:9696
+    - publicurl: http://{{ int_ip }}:9696
     - internalurl: http://{{ int_ip }}:9696
     - adminurl: http://{{ int_ip }}:9696
     - require:

--- a/openstack/neutron/files/mitaka/neutron+agent+linux+ip_lib.py
+++ b/openstack/neutron/files/mitaka/neutron+agent+linux+ip_lib.py
@@ -125,12 +125,21 @@ class IPWrapper(SubProcessBase):
             # we call out manually because in order to avoid screen scraping
             # iproute2 we use find to see what is in the sysfs directory, as
             # suggested by Stephen Hemminger (iproute2 dev).
-            output = utils.execute(['ip', 'netns', 'exec', self.namespace,
-                                    'find', SYS_NET_PATH, '-maxdepth', '1',
-                                    '-type', 'l', '-printf', '%f '],
-                                   run_as_root=True,
-                                   log_fail_as_error=self.log_fail_as_error
-                                   ).split()
+            try:
+                cmd = ['ip', 'netns', 'exec', self.namespace,
+                       'find', SYS_NET_PATH, '-maxdepth', '1',
+                       '-type', 'l', '-printf', '%f ']
+                output = utils.execute(
+                    cmd,
+                    run_as_root=True,
+                    log_fail_as_error=self.log_fail_as_error).split()
+            except RuntimeError:
+                # We could be racing with a cron job deleting namespaces.
+                # Just return a empty list if the namespace is deleted.
+                with excutils.save_and_reraise_exception() as ctx:
+                    if not self.netns.exists(self.namespace):
+                        ctx.reraise = False
+                        return []
         else:
             output = (
                 i for i in os.listdir(SYS_NET_PATH)
@@ -864,6 +873,13 @@ class IpRouteCommand(IpDeviceCommandBase):
                                   ('append', subnet,
                                    'proto', 'kernel',
                                    'dev', device))
+
+    def flush(self, ip_version, table=None, **kwargs):
+        args = ['flush']
+        args += self._table_args(table)
+        for k, v in kwargs.items():
+            args += [k, v]
+        self._as_root([ip_version], tuple(args))
 
     def add_route(self, cidr, via=None, table=None, **kwargs):
         ip_version = get_ip_version(cidr)

--- a/openstack/neutron/files/mitaka/neutron+common+utils.py
+++ b/openstack/neutron/files/mitaka/neutron+common+utils.py
@@ -398,6 +398,21 @@ def get_other_dvr_serviced_device_owners():
             n_const.DEVICE_OWNER_DHCP]
 
 
+def get_dvr_allowed_address_pair_device_owners():
+    """Return device_owner names for allowed_addr_pair ports serviced by DVR
+
+    This just returns the device owners that are used by the
+    allowed_address_pair ports. Right now only the device_owners shown
+    below are used by the allowed_address_pair ports.
+    Later if other device owners are used for allowed_address_pairs those
+    device_owners should be added to the list below.
+    """
+    # TODO(Swami): Convert these methods to constants.
+    # Add the constants variable to the neutron-lib
+    return [n_const.DEVICE_OWNER_LOADBALANCER,
+            n_const.DEVICE_OWNER_LOADBALANCERV2]
+
+
 def is_dvr_serviced(device_owner):
     """Check if the port need to be serviced by DVR
 
@@ -420,6 +435,7 @@ def get_keystone_url(conf):
              'host': conf.auth_host,
              'port': conf.auth_port})
     # NOTE(ihrachys): all existing consumers assume version 2.0
+    # NOTE(mirlos): VIRL should be 3 by now
     return '%s/v3/' % auth_uri
 
 

--- a/openstack/neutron/files/mitaka/neutron+plugins+ml2+drivers+agent+_common_agent.py
+++ b/openstack/neutron/files/mitaka/neutron+plugins+ml2+drivers+agent+_common_agent.py
@@ -210,7 +210,7 @@ class CommonAgentLoop(service.Service):
     def treat_devices_added_updated(self, devices):
         try:
             devices_details_list = self.plugin_rpc.get_devices_details_list(
-                self.context, devices, self.agent_id)
+                self.context, devices, self.agent_id, host=cfg.CONF.host)
         except Exception:
             LOG.exception(_LE("Unable to get port details for %s"), devices)
             # resync is needed

--- a/openstack/neutron/files/mitaka/neutron+plugins+ml2+drivers+linuxbridge+agent+linuxbridge_neutron_agent.py
+++ b/openstack/neutron/files/mitaka/neutron+plugins+ml2+drivers+linuxbridge+agent+linuxbridge_neutron_agent.py
@@ -374,7 +374,7 @@ class LinuxBridgeManager(amb.CommonAgentManagerBase):
         if bridge_name not in self.known_bridges:
             bridge_device.set_group_fwd_mask()
             bridge_device.set_ageing(cfg.CONF.network_bridge_ageing,
-                                     cfg.CONF.network_physical_ageing,
+                                     cfg.CONG.network_physical_ageing,
                                      physical)
             bridge_device.set_multicast_snooping(cfg.CONF.network_bridge_multicast_snooping)
             bridge_device.disable_stp()
@@ -719,10 +719,12 @@ class LinuxBridgeManager(amb.CommonAgentManagerBase):
         return (agent_ip in entries and mac in entries)
 
     def add_fdb_ip_entry(self, mac, ip, interface):
-        ip_lib.IPDevice(interface).neigh.add(ip, mac)
+        if cfg.CONF.VXLAN.arp_responder:
+            ip_lib.IPDevice(interface).neigh.add(ip, mac)
 
     def remove_fdb_ip_entry(self, mac, ip, interface):
-        ip_lib.IPDevice(interface).neigh.delete(ip, mac)
+        if cfg.CONF.VXLAN.arp_responder:
+            ip_lib.IPDevice(interface).neigh.delete(ip, mac)
 
     def add_fdb_bridge_entry(self, mac, agent_ip, interface, operation="add"):
         utils.execute(['bridge', 'fdb', operation, mac, 'dev', interface,

--- a/openstack/neutron/files/mitaka/neutron+plugins+ml2+rpc.py
+++ b/openstack/neutron/files/mitaka/neutron+plugins+ml2+rpc.py
@@ -27,9 +27,11 @@ from neutron.common import constants as n_const
 from neutron.common import exceptions
 from neutron.common import rpc as n_rpc
 from neutron.common import topics
+from neutron.db import l3_hamode_db
 from neutron.extensions import portbindings
 from neutron.extensions import portsecurity as psec
 from neutron import manager
+from neutron.plugins.ml2 import db as ml2_db
 from neutron.plugins.ml2 import driver_api as api
 from neutron.plugins.ml2.drivers import type_tunnel
 from neutron.services.qos import qos_consts
@@ -186,16 +188,18 @@ class RpcCallbacks(type_tunnel.TunnelRpcCallbackMixin):
             LOG.debug("Device %(device)s not bound to the"
                       " agent host %(host)s",
                       {'device': device, 'host': host})
-            return {'device': device,
-                    'exists': port_exists}
-
-        try:
-            port_exists = bool(plugin.update_port_status(
-                rpc_context, port_id, n_const.PORT_STATUS_DOWN, host))
-        except exc.StaleDataError:
-            port_exists = False
-            LOG.debug("delete_port and update_device_down are being executed "
-                      "concurrently. Ignoring StaleDataError.")
+        else:
+            try:
+                port_exists = bool(plugin.update_port_status(
+                    rpc_context, port_id, n_const.PORT_STATUS_DOWN, host))
+            except exc.StaleDataError:
+                port_exists = False
+                LOG.debug("delete_port and update_device_down are being "
+                          "executed concurrently. Ignoring StaleDataError.")
+                return {'device': device,
+                        'exists': port_exists}
+        self.notify_ha_port_status(port_id, rpc_context,
+                                   n_const.PORT_STATUS_DOWN, host)
 
         return {'device': device,
                 'exists': port_exists}
@@ -214,8 +218,13 @@ class RpcCallbacks(type_tunnel.TunnelRpcCallbackMixin):
             LOG.debug("Device %(device)s not bound to the"
                       " agent host %(host)s",
                       {'device': device, 'host': host})
-            return
+        else:
+            self.update_port_status_to_active(rpc_context, port_id, host)
+        self.notify_ha_port_status(port_id, rpc_context,
+                                   n_const.PORT_STATUS_ACTIVE, host)
 
+    def update_port_status_to_active(self, rpc_context, port_id, host):
+        plugin = manager.NeutronManager.get_plugin()
         port_id = plugin.update_port_status(rpc_context, port_id,
                                             n_const.PORT_STATUS_ACTIVE,
                                             host)
@@ -234,6 +243,28 @@ class RpcCallbacks(type_tunnel.TunnelRpcCallbackMixin):
             }
             registry.notify(
                 resources.PORT, events.AFTER_UPDATE, plugin, **kwargs)
+
+    def notify_ha_port_status(self, port_id, rpc_context,
+                              status, host):
+        plugin = manager.NeutronManager.get_plugin()
+        l2pop_driver = plugin.mechanism_manager.mech_drivers.get(
+                'l2population')
+        if not l2pop_driver:
+            return
+        port = ml2_db.get_port(rpc_context.session, port_id)
+        if not port:
+            return
+        is_ha_port = l3_hamode_db.is_ha_router_port(port['device_owner'],
+                                                    port['device_id'])
+        if is_ha_port:
+            port_context = plugin.get_bound_port_context(
+                    rpc_context, port_id)
+            port_context.current['status'] = status
+            port_context.current[portbindings.HOST_ID] = host
+            if status == n_const.PORT_STATUS_ACTIVE:
+                l2pop_driver.obj.update_port_up(port_context)
+            else:
+                l2pop_driver.obj.update_port_down(port_context)
 
     def update_device_list(self, rpc_context, **kwargs):
         devices_up = []

--- a/openstack/nova/files/compute.nova.conf
+++ b/openstack/nova/files/compute.nova.conf
@@ -94,11 +94,22 @@ enabled = false
 
 [neutron]
 url = http://{{ virl.controller_ip }}:9696
+{% if virl.mitaka %}
+auth_type = password
+project_name = service
+username = neutron
+password = password
+auth_url = http://{{ virl.controller_ip }}:35357/{{ virl.keystone_auth_version }}
+auth_protocol = http
+project_domain_id = default
+user_domain_id = default
+{% else %}
 auth_strategy = keystone
 admin_tenant_name = service
 admin_username = neutron
 admin_password = {{salt['pillar.get']('virl:password', salt['grains.get']('password', 'password')) }}
 admin_auth_url = http://{{ virl.controller_ip }}:35357/{{ virl.keystone_auth_version }}
+{% endif %}
 
 [serial_console]
 proxyclient_address = 0.0.0.0

--- a/openstack/nova/files/mitaka/nova+compute+cells_api.py
+++ b/openstack/nova/files/mitaka/nova+compute+cells_api.py
@@ -24,6 +24,7 @@ from nova.cells import rpcapi as cells_rpcapi
 from nova.cells import utils as cells_utils
 from nova.compute import api as compute_api
 from nova.compute import rpcapi as compute_rpcapi
+from nova.compute import vm_states
 from nova import exception
 from nova import objects
 from nova.objects import base as obj_base
@@ -321,10 +322,10 @@ class ComputeCellsAPI(compute_api.API):
 
     @wrap_check_policy
     @check_instance_cell
+    @check_instance_state(vm_state=[vm_states.ACTIVE, vm_states.STOPPED,
+                                    vm_states.PAUSED, vm_states.SUSPENDED])
     def shelve(self, context, instance, clean_shutdown=True):
         """Shelve the given instance."""
-        super(ComputeCellsAPI, self).shelve(context, instance,
-                clean_shutdown=clean_shutdown)
         self._cast_to_cells(context, instance, 'shelve',
                 clean_shutdown=clean_shutdown)
 
@@ -339,9 +340,10 @@ class ComputeCellsAPI(compute_api.API):
 
     @wrap_check_policy
     @check_instance_cell
+    @check_instance_state(vm_state=[vm_states.SHELVED,
+                                    vm_states.SHELVED_OFFLOADED])
     def unshelve(self, context, instance):
         """Unshelve the given instance."""
-        super(ComputeCellsAPI, self).unshelve(context, instance)
         self._cast_to_cells(context, instance, 'unshelve')
 
     @wrap_check_policy

--- a/openstack/nova/files/mitaka/nova+compute+manager.py
+++ b/openstack/nova/files/mitaka/nova+compute+manager.py
@@ -3543,7 +3543,8 @@ class ComputeManager(manager.Manager):
                 migration.save()
 
             rt = self._get_resource_tracker(migration.source_node)
-            rt.drop_move_claim(context, instance, old_instance_type)
+            rt.drop_move_claim(context, instance, old_instance_type,
+                               prefix='old_')
 
             # NOTE(mriedem): The old_vm_state could be STOPPED but the user
             # might have manually powered up the instance to confirm the
@@ -4254,6 +4255,14 @@ class ComputeManager(manager.Manager):
         :param image_id: an image id to snapshot to.
         :param clean_shutdown: give the GuestOS a chance to stop
         """
+
+        @utils.synchronized(instance.uuid)
+        def do_shelve_instance():
+            self._shelve_instance(context, instance, image_id, clean_shutdown)
+        do_shelve_instance()
+
+    def _shelve_instance(self, context, instance, image_id,
+                         clean_shutdown):
         compute_utils.notify_usage_exists(self.notifier, context, instance,
                                           current_period=True)
         self._notify_about_instance_usage(context, instance, 'shelve.start')
@@ -4288,8 +4297,8 @@ class ComputeManager(manager.Manager):
         self._notify_about_instance_usage(context, instance, 'shelve.end')
 
         if CONF.shelved_offload_time == 0:
-            self.shelve_offload_instance(context, instance,
-                                         clean_shutdown=False)
+            self._shelve_offload_instance(context, instance,
+                                          clean_shutdown=False)
 
     @wrap_exception()
     @reverts_task_state
@@ -4306,6 +4315,13 @@ class ComputeManager(manager.Manager):
         :param instance: nova.objects.instance.Instance
         :param clean_shutdown: give the GuestOS a chance to stop
         """
+
+        @utils.synchronized(instance.uuid)
+        def do_shelve_offload_instance():
+            self._shelve_offload_instance(context, instance, clean_shutdown)
+        do_shelve_offload_instance()
+
+    def _shelve_offload_instance(self, context, instance, clean_shutdown):
         self._notify_about_instance_usage(context, instance,
                 'shelve_offload.start')
 
@@ -4321,14 +4337,18 @@ class ComputeManager(manager.Manager):
                 block_device_info)
 
         instance.power_state = current_power_state
-        instance.host = None
-        instance.node = None
         instance.vm_state = vm_states.SHELVED_OFFLOADED
         instance.task_state = None
         instance.save(expected_task_state=[task_states.SHELVING,
                                            task_states.SHELVING_OFFLOADING])
-        # NOTE(ndipanov): This frees the resources with the resource_tracker
+
+        # NOTE(ndipanov): Free resources from the resource tracker
         self._update_resource_tracker(context, instance)
+
+        # NOTE(sfinucan): RPC calls should no longer be attempted against this
+        # instance, so ensure any calls result in errors
+        self._nil_out_instance_obj_host_and_node(instance)
+        instance.save(expected_task_state=None)
 
         self._delete_scheduler_instance_info(context, instance.uuid)
         self._notify_about_instance_usage(context, instance,
@@ -4747,7 +4767,7 @@ class ComputeManager(manager.Manager):
         self._notify_about_instance_usage(
             context, instance, "volume.attach", extra_usage_info=info)
 
-    def _driver_detach_volume(self, context, instance, bdm):
+    def _driver_detach_volume(self, context, instance, bdm, connection_info):
         """Do the actual driver detach using block device mapping."""
         mp = bdm.device_name
         volume_id = bdm.volume_id
@@ -4756,11 +4776,6 @@ class ComputeManager(manager.Manager):
                   {'volume_id': volume_id, 'mp': mp},
                   context=context, instance=instance)
 
-        connection_info = jsonutils.loads(bdm.connection_info)
-        # NOTE(vish): We currently don't use the serial when disconnecting,
-        #             but added for completeness in case we ever do.
-        if connection_info and 'serial' not in connection_info:
-            connection_info['serial'] = volume_id
         try:
             if not self.driver.instance_exists(instance):
                 LOG.warning(_LW('Detaching volume from unknown instance'),
@@ -4785,8 +4800,6 @@ class ComputeManager(manager.Manager):
                               {'volume_id': volume_id, 'mp': mp},
                               context=context, instance=instance)
                 self.volume_api.roll_detaching(context, volume_id)
-
-        return connection_info
 
     def _detach_volume(self, context, volume_id, instance, destroy_bdm=True,
                        attachment_id=None):
@@ -4832,8 +4845,21 @@ class ComputeManager(manager.Manager):
                 self.notifier.info(context, 'volume.usage',
                                    compute_utils.usage_volume_info(vol_usage))
 
-        connection_info = self._driver_detach_volume(context, instance, bdm)
+        connection_info = jsonutils.loads(bdm.connection_info)
         connector = self.driver.get_volume_connector(instance)
+        if CONF.host == instance.host:
+            # Only attempt to detach and disconnect from the volume if the
+            # instance is currently associated with the local compute host.
+            self._driver_detach_volume(context, instance, bdm, connection_info)
+        elif not destroy_bdm:
+            LOG.debug("Skipping _driver_detach_volume during remote rebuild.",
+                      instance=instance)
+        elif destroy_bdm:
+            LOG.error(_LE("Unable to call for a driver detach of volume "
+                          "%(vol_id)s due to the instance being registered to "
+                          "the remote host %(inst_host)s."),
+                      {'vol_id': volume_id, 'inst_host': instance.host},
+                      instance=instance)
 
         if connection_info and not destroy_bdm and (
            connector.get('host') != instance.host):
@@ -5022,7 +5048,8 @@ class ComputeManager(manager.Manager):
         try:
             bdm = objects.BlockDeviceMapping.get_by_volume_and_instance(
                     context, volume_id, instance.uuid)
-            self._driver_detach_volume(context, instance, bdm)
+            connection_info = jsonutils.loads(bdm.connection_info)
+            self._driver_detach_volume(context, instance, bdm, connection_info)
             connector = self.driver.get_volume_connector(instance)
             self.volume_api.terminate_connection(context, volume_id, connector)
         except exception.NotFound:
@@ -5282,7 +5309,7 @@ class ComputeManager(manager.Manager):
             with excutils.save_and_reraise_exception():
                 LOG.exception(_LE('Pre live migration failed at %s'),
                               dest, instance=instance)
-                self._set_migration_status(migration, 'failed')
+                self._set_migration_status(migration, 'error')
                 self._rollback_live_migration(context, instance, dest,
                                               block_migration, migrate_data)
 
@@ -5302,7 +5329,7 @@ class ComputeManager(manager.Manager):
             # nothing must be recovered in this version.
             LOG.exception(_LE('Live migration failed.'), instance=instance)
             with excutils.save_and_reraise_exception():
-                self._set_migration_status(migration, 'failed')
+                self._set_migration_status(migration, 'error')
 
     @wrap_exception()
     @wrap_instance_event
@@ -6793,28 +6820,29 @@ class ComputeManager(manager.Manager):
                                          in migrations])
 
         inst_filters = {'deleted': True, 'soft_deleted': False,
-                        'uuid': inst_uuid_from_migrations, 'host': CONF.host}
+                        'uuid': inst_uuid_from_migrations}
         attrs = ['info_cache', 'security_groups', 'system_metadata']
         with utils.temporary_mutation(context, read_deleted='yes'):
             instances = objects.InstanceList.get_by_filters(
                 context, inst_filters, expected_attrs=attrs, use_slave=True)
 
         for instance in instances:
-            for migration in migrations:
-                if instance.uuid == migration.instance_uuid:
-                    # Delete instance files if not cleanup properly either
-                    # from the source or destination compute nodes when
-                    # the instance is deleted during resizing.
-                    self.driver.delete_instance_files(instance)
-                    try:
-                        migration.status = 'failed'
-                        with migration.obj_as_admin():
-                            migration.save()
-                    except exception.MigrationNotFound:
-                        LOG.warning(_LW("Migration %s is not found."),
-                                    migration.id, context=context,
-                                    instance=instance)
-                    break
+            if instance.host != CONF.host:
+                for migration in migrations:
+                    if instance.uuid == migration.instance_uuid:
+                        # Delete instance files if not cleanup properly either
+                        # from the source or destination compute nodes when
+                        # the instance is deleted during resizing.
+                        self.driver.delete_instance_files(instance)
+                        try:
+                            migration.status = 'failed'
+                            with migration.obj_as_admin():
+                                migration.save()
+                        except exception.MigrationNotFound:
+                            LOG.warning(_LW("Migration %s is not found."),
+                                        migration.id, context=context,
+                                        instance=instance)
+                        break
 
     @messaging.expected_exceptions(exception.InstanceQuiesceNotSupported,
                                    exception.QemuGuestAgentNotEnabled,

--- a/openstack/nova/files/mitaka/nova+compute+rpcapi.py
+++ b/openstack/nova/files/mitaka/nova+compute+rpcapi.py
@@ -645,6 +645,7 @@ class ComputeAPI(object):
                     pre_migration_result=True)
         if not self.client.can_send_version(version):
             version = '4.0'
+            args.pop('migration')
         cctxt = self.client.prepare(server=host, version=version)
         cctxt.cast(ctxt, 'live_migration', instance=instance,
                    dest=dest, block_migration=block_migration,

--- a/openstack/nova/files/mitaka/nova+virt+driver.py
+++ b/openstack/nova/files/mitaka/nova+virt+driver.py
@@ -24,6 +24,7 @@ import sys
 
 from oslo_log import log as logging
 from oslo_utils import importutils
+import six
 
 import nova.conf
 from nova.i18n import _, _LE, _LI
@@ -1433,7 +1434,7 @@ class ComputeDriver(object):
         """
 
         if not self._compute_event_callback:
-            LOG.debug("Discarding event %s", str(event))
+            LOG.debug("Discarding event %s", six.text_type(event))
             return
 
         if not isinstance(event, virtevent.Event):
@@ -1441,7 +1442,7 @@ class ComputeDriver(object):
                 _("Event must be an instance of nova.virt.event.Event"))
 
         try:
-            LOG.debug("Emitting event %s", str(event))
+            LOG.debug("Emitting event %s", six.text_type(event))
             self._compute_event_callback(event)
         except Exception as ex:
             LOG.error(_LE("Exception dispatching event %(event)s: %(ex)s"),

--- a/openstack/nova/files/mitaka/nova+virt+hardware.py
+++ b/openstack/nova/files/mitaka/nova+virt+hardware.py
@@ -832,8 +832,9 @@ def _numa_fit_instance_cell_with_pinning(host_cell, instance_cell):
     else:
         # Straightforward to pin to available cpus when there is no
         # hyperthreading on the host
+        free_cpus = [set([cpu]) for cpu in host_cell.free_cpus]
         return _pack_instance_onto_cores(
-            [host_cell.free_cpus], instance_cell, host_cell.id)
+            free_cpus, instance_cell, host_cell.id)
 
 
 def _numa_fit_instance_cell(host_cell, instance_cell, limit_cell=None):

--- a/openstack/nova/files/mitaka/nova+virt+libvirt+vif.py
+++ b/openstack/nova/files/mitaka/nova+virt+libvirt+vif.py
@@ -628,10 +628,9 @@ class LibvirtGenericVIFDriver(object):
             utils.execute('ifc_ctl', 'gateway', 'add_port', dev,
                           run_as_root=True)
             utils.execute('ifc_ctl', 'gateway', 'ifup', dev,
-                          'access_vm',
-                          vif['network']['label'] + "_" + iface_id,
-                          vif['address'], 'pgtag2=%s' % net_id,
-                          'pgtag1=%s' % tenant_id, run_as_root=True)
+                          'access_vm', iface_id, vif['address'],
+                          'pgtag2=%s' % net_id, 'pgtag1=%s' % tenant_id,
+                          run_as_root=True)
         except processutils.ProcessExecutionError:
             LOG.exception(_LE("Failed while plugging vif"), instance=instance)
 
@@ -894,13 +893,10 @@ class LibvirtGenericVIFDriver(object):
         Delete network device and to their respective
         connection to the Virtual Domain in PLUMgrid Platform.
         """
-        iface_id = vif['id']
         dev = self.get_vif_devname(vif)
         try:
             utils.execute('ifc_ctl', 'gateway', 'ifdown',
-                          dev, 'access_vm',
-                          vif['network']['label'] + "_" + iface_id,
-                          vif['address'], run_as_root=True)
+                          dev, run_as_root=True)
             utils.execute('ifc_ctl', 'gateway', 'del_port', dev,
                           run_as_root=True)
             linux_net.delete_net_dev(dev)


### PR DESCRIPTION
So first is an update to our replaced modules, merged from upstream with tiny changes.

Second is nova's config for neutron that got VMs working on the testing mitaka cluster. Note that now the computes use the public url of the controller, hence I had to change the endpoint url.

Note that I did all this manually, not using salt calls.