### PR TITLE
Release lxc

### DIFF
--- a/_modules/virl_core.py
+++ b/_modules/virl_core.py
@@ -361,9 +361,15 @@ def lxc_image_show(id=None, name=None):
 
 def lxc_image_create(subtype, version='', release=None, **properties):
     name = '%s-%s' % (subtype, version) if version else subtype
-    img_salt_path = 'salt://images/salt/%s.tar.gz' % name
-    img_path = __salt__['cp.cache_file'](img_salt_path)
-    if not img_path:
+    salt_names = [name]
+    if release is not None:
+        salt_names.insert(0, '%s-%s' % (name, release))
+    for salt_name in salt_names:
+        img_salt_path = 'salt://images/salt/%s.tar.gz' % salt_name
+        img_path = __salt__['cp.cache_file'](img_salt_path)
+        if img_path:
+            break
+    else:
         raise Exception('Could not find %s' % img_salt_path)
 
     creation_params = {

--- a/virl/routervms/lxc_server.sls
+++ b/virl/routervms/lxc_server.sls
@@ -1,3 +1,4 @@
+{% from "virl.jinja" import virl with context %}
 {% set lxc_server = salt['pillar.get']('lxcimages:lxc_server', True) %}
 {% set lxc_server_pref = salt['pillar.get']('virl:lxc_server', salt['grains.get']('lxc_server', True)) %}
 {% set cml = salt['grains.get']('cml', False) %}
@@ -11,7 +12,11 @@ lxc_server:
   virl_core.lxc_image_present:
   - subtype: lxc
   - version: ubuntu-ci
+  {% if virl.mitaka %}
+  - release: 16.04.0
+  {% else %}
   - release: 14.04.2
+  {% endif %}
 
   {% if not cml %}
 remove dead tar:


### PR DESCRIPTION
This should make images/salt/lxc-ubuntu-ci-16.04.0.tar.gz work on mitaka as the source of the file, while falling back to images/salt/lxc-ubuntu-ci.tar.gz if the version with the release isn't found.