### PR TITLE
Explicitly indicate that the bridge module was patched by Cisco

### DIFF
--- a/common/scripts/bridgebuilder.sh
+++ b/common/scripts/bridgebuilder.sh
@@ -8,6 +8,7 @@ apt-get install -y linux-headers-$version
 apt-get source -y linux-image-$version
 cd linux*/
 sed -i -e '/BR_GROUPFWD_RESTRICTED/s/0x.*u/0x0u/' net/bridge/br_private.h
+sed -i -e '/MODULE_VERSION/iMODULE_INFO(ciscopatch, "BR_GROUPFWD_RESTRICTED_v2");' net/bridge/br.c
 cp /usr/src/linux-headers-$version/Module.symvers .
 make olddefconfig
 make prepare modules_prepare


### PR DESCRIPTION
We were relying on a module metadata that is no longer present even in upstream kernel module, which meant we marked all kernels as applied. This adds a custom field into our module so that UWM can look for it.