### PR TITLE
Fix some CML failures

### DIFF
--- a/virl/std/install.sls
+++ b/virl/std/install.sls
@@ -182,7 +182,11 @@ VIRL_CORE_dead:
       - virl-std
       - virl-uwm
     - prereq:
+{% if virl.cml %}
+      - pip: CML_CORE
+{% else %}
       - pip: VIRL_CORE
+{% endif %}
 {% if not virl.mitaka %}
     - require:
       - file: /etc/rc2.d/S98virl-std
@@ -301,7 +305,11 @@ ank preview port:
       # new location
       - crudini --set /etc/virl/virl-core.ini host ank_preview_port {{ virl.ank }}
     - require:
+{% if virl.cml %}
+      - pip: CML_CORE
+{% else %}
       - pip: VIRL_CORE
+{% endif %}
 
 web editor alpha:
 {% if virl.web_editor %}
@@ -317,7 +325,11 @@ web editor alpha:
     - repl: ''
 {% endif %}
     - require:
+{% if virl.cml %}
+      - pip: CML_CORE
+{% else %}
       - pip: VIRL_CORE
+{% endif %}
 
 {% if virl.cluster %}
 enable cluster in std :
@@ -327,7 +339,11 @@ enable cluster in std :
       # new location
       - crudini --set /etc/virl/virl-core.ini orchestration cluster_mode True
     - require:
+{% if virl.cml %}
+      - pip: CML_CORE
+{% else %}
       - pip: VIRL_CORE
+{% endif %}
 
 point std at key:
   cmd.run:
@@ -339,7 +355,11 @@ point std at key:
       - test -e ~virl/.ssh/id_rsa.pub
       - test -e /etc/virl/common.cfg
     - require:
+{% if virl.cml %}
+      - pip: CML_CORE
+{% else %}
       - pip: VIRL_CORE
+{% endif %}
 
   {% if virl.compute4_active %}
 
@@ -350,7 +370,11 @@ add up to cluster4 to std:
       # new location
       - crudini --set /etc/virl/virl-core.ini cluster computes '{{virl.compute1_hostname}},{{virl.compute2_hostname}},{{virl.compute3_hostname}},{{virl.compute4_hostname}}'
     - require:
+{% if virl.cml %}
+      - pip: CML_CORE
+{% else %}
       - pip: VIRL_CORE
+{% endif %}
 
   {% elif virl.compute3_active %}
 
@@ -361,7 +385,11 @@ add up to cluster3 to std:
       # new location
       - crudini --set /etc/virl/virl-core.ini cluster computes '{{virl.compute1_hostname}},{{virl.compute2_hostname}},{{virl.compute3_hostname}}'
     - require:
+{% if virl.cml %}
+      - pip: CML_CORE
+{% else %}
       - pip: VIRL_CORE
+{% endif %}
 
   {% elif virl.compute2_active %}
 
@@ -372,7 +400,11 @@ add up to cluster2 to std:
       # new location
       - crudini --set /etc/virl/virl-core.ini cluster computes '{{virl.compute1_hostname}},{{virl.compute2_hostname}}'
     - require:
+{% if virl.cml %}
+      - pip: CML_CORE
+{% else %}
       - pip: VIRL_CORE
+{% endif %}
 
   {% else %}
 
@@ -383,7 +415,11 @@ add only cluster1 to std:
       # new location
       - crudini --set /etc/virl/virl-core.ini cluster computes '{{virl.compute1_hostname}}'
     - require:
+{% if virl.cml %}
+      - pip: CML_CORE
+{% else %}
       - pip: VIRL_CORE
+{% endif %}
 
   {% endif %}
 
@@ -432,7 +468,11 @@ virl db upgrade init:
   cmd.run:
     - name: /usr/local/bin/virl_uwm_server upgrade
     - require:
+{% if virl.cml %}
+      - pip: CML_CORE
+{% else %}
       - pip: VIRL_CORE
+{% endif %}
 
 virl-std:
   service:

--- a/virl/std/install.sls
+++ b/virl/std/install.sls
@@ -182,11 +182,7 @@ VIRL_CORE_dead:
       - virl-std
       - virl-uwm
     - prereq:
-{% if virl.cml %}
-      - pip: CML_CORE
-{% else %}
       - pip: VIRL_CORE
-{% endif %}
 {% if not virl.mitaka %}
     - require:
       - file: /etc/rc2.d/S98virl-std
@@ -305,11 +301,7 @@ ank preview port:
       # new location
       - crudini --set /etc/virl/virl-core.ini host ank_preview_port {{ virl.ank }}
     - require:
-{% if virl.cml %}
-      - pip: CML_CORE
-{% else %}
       - pip: VIRL_CORE
-{% endif %}
 
 web editor alpha:
 {% if virl.web_editor %}
@@ -325,11 +317,7 @@ web editor alpha:
     - repl: ''
 {% endif %}
     - require:
-{% if virl.cml %}
-      - pip: CML_CORE
-{% else %}
       - pip: VIRL_CORE
-{% endif %}
 
 {% if virl.cluster %}
 enable cluster in std :
@@ -339,11 +327,7 @@ enable cluster in std :
       # new location
       - crudini --set /etc/virl/virl-core.ini orchestration cluster_mode True
     - require:
-{% if virl.cml %}
-      - pip: CML_CORE
-{% else %}
       - pip: VIRL_CORE
-{% endif %}
 
 point std at key:
   cmd.run:
@@ -355,11 +339,7 @@ point std at key:
       - test -e ~virl/.ssh/id_rsa.pub
       - test -e /etc/virl/common.cfg
     - require:
-{% if virl.cml %}
-      - pip: CML_CORE
-{% else %}
       - pip: VIRL_CORE
-{% endif %}
 
   {% if virl.compute4_active %}
 
@@ -370,11 +350,7 @@ add up to cluster4 to std:
       # new location
       - crudini --set /etc/virl/virl-core.ini cluster computes '{{virl.compute1_hostname}},{{virl.compute2_hostname}},{{virl.compute3_hostname}},{{virl.compute4_hostname}}'
     - require:
-{% if virl.cml %}
-      - pip: CML_CORE
-{% else %}
       - pip: VIRL_CORE
-{% endif %}
 
   {% elif virl.compute3_active %}
 
@@ -385,11 +361,7 @@ add up to cluster3 to std:
       # new location
       - crudini --set /etc/virl/virl-core.ini cluster computes '{{virl.compute1_hostname}},{{virl.compute2_hostname}},{{virl.compute3_hostname}}'
     - require:
-{% if virl.cml %}
-      - pip: CML_CORE
-{% else %}
       - pip: VIRL_CORE
-{% endif %}
 
   {% elif virl.compute2_active %}
 
@@ -400,11 +372,7 @@ add up to cluster2 to std:
       # new location
       - crudini --set /etc/virl/virl-core.ini cluster computes '{{virl.compute1_hostname}},{{virl.compute2_hostname}}'
     - require:
-{% if virl.cml %}
-      - pip: CML_CORE
-{% else %}
       - pip: VIRL_CORE
-{% endif %}
 
   {% else %}
 
@@ -415,11 +383,7 @@ add only cluster1 to std:
       # new location
       - crudini --set /etc/virl/virl-core.ini cluster computes '{{virl.compute1_hostname}}'
     - require:
-{% if virl.cml %}
-      - pip: CML_CORE
-{% else %}
       - pip: VIRL_CORE
-{% endif %}
 
   {% endif %}
 
@@ -468,11 +432,7 @@ virl db upgrade init:
   cmd.run:
     - name: /usr/local/bin/virl_uwm_server upgrade
     - require:
-{% if virl.cml %}
-      - pip: CML_CORE
-{% else %}
       - pip: VIRL_CORE
-{% endif %}
 
 virl-std:
   service:

--- a/virl/std/install.sls
+++ b/virl/std/install.sls
@@ -419,9 +419,7 @@ virl init:
   cmd:
     - run
     - name: /usr/local/bin/virl_uwm_server init -A http://127.0.1.1:5000/{{ virl.keystone_auth_version }} -u uwmadmin -p {{ virl.uwmpassword }} -U uwmadmin -P {{ virl.uwmpassword }} -T uwmadmin
-    {% if not virl.mitaka %}
     - onlyif: 'test ! -e /var/local/virl/servers.db'
-    {% endif %}
 
 virl init second:
   cmd:
@@ -453,6 +451,7 @@ virl-uwm:
 virl init failsafe:
   cmd.run:
     - name: /usr/local/bin/virl_uwm_server init -A http://127.0.1.1:5000/{{ virl.keystone_auth_version }} -u uwmadmin -p {{ virl.uwmpassword }} -U uwmadmin -P {{ virl.uwmpassword }} -T uwmadmin
+    - onlyif: 'test ! -e /var/local/virl/servers.db'
     - require:
       - service: virl-uwm
       - service: virl-std


### PR DESCRIPTION
There are still files missing on CML salt when running virl.std install/clients but this should take care of the most serious issues.