### PR TITLE
Use older name for lxc-ostinato for virl-core 0.10.28.x

### DIFF
--- a/virl/routervms/lxc_ostinato.sls
+++ b/virl/routervms/lxc_ostinato.sls
@@ -3,16 +3,20 @@
 include:
   - virl.routervms.virl-core-sync
 
-{% if virl.lxc_ostinato and virl.lxc_ostinatopref %}
-
+# get rid of any old version
 lxc_ostinato_gone:
   virl_core.lxc_image_absent:
   - subtype: lxc-ostinato
   - version: standard
 
+{% if virl.lxc_ostinato and virl.lxc_ostinatopref %}
+
+# original virl-core for 1.2.* needs to use older name
+{% set subtype_reported = 'lxc-ostinato' + ('' if '0.10.28' in salt['pillar.get']('files:virl', '') else '-drone') %}
+
 lxc_ostinato:
   virl_core.lxc_image_present:
-  - subtype: lxc-ostinato-drone
+  - subtype: {{ subtype_reported }}
   - version: standard
   - release: 0.8
 
@@ -20,7 +24,7 @@ lxc_ostinato:
 
 lxc_ostinato gone:
   virl_core.lxc_image_absent:
-  - subtype: lxc-ostinato-drone
+  - subtype: {{ subtype_reported }}
   - version: standard
 
 {% endif %}


### PR DESCRIPTION
@bd204 please see if this would work for you wrt the old name.