### PR TITLE
Prevent overloading computes

### DIFF
--- a/common/salt-master/cluster.sls
+++ b/common/salt-master/cluster.sls
@@ -51,7 +51,7 @@ compute filter for cluster controller:
     - filename: /etc/nova/nova.conf
     - section: 'DEFAULT'
     - parameter: 'scheduler_default_filters'
-    - value: 'AllHostsFilter,ComputeFilter'
+    - value: 'RamFilter,AllHostsFilter,ComputeFilter'
     - onlyif: test -e /etc/nova/nova.conf
 
 {% if controller %}

--- a/openstack/nova/compute.sls
+++ b/openstack/nova/compute.sls
@@ -87,7 +87,7 @@ compute filter for compute paranoia:
     - filename: /etc/nova/nova.conf
     - section: 'DEFAULT'
     - parameter: 'scheduler_default_filters'
-    - value: 'AllHostsFilter,ComputeFilter'
+    - value: 'RamFilter,AllHostsFilter,ComputeFilter'
     - require:
       - file: /etc/nova/nova.conf
 

--- a/openstack/nova/files/compute.nova.conf
+++ b/openstack/nova/files/compute.nova.conf
@@ -60,6 +60,7 @@ vncserver_proxyclient_address = {{  salt['pillar.get']('virl:static_ip', salt['g
 novncproxy_port = {{ salt['pillar.get']('virl:vnc_port', salt['grains.get']('vnc_port', 19407)) }}
 novncproxy_base_url = http://127.0.1.1:{{ salt['pillar.get']('virl:vnc_port', salt['grains.get']('vnc_port', '19407')) }}/vnc_auto.html
 
+ram_allocation_ratio = 5.0
 scheduler_default_filters= {{  salt['pillar.get']('virl:nova_filter', salt['grains.get']('nova_filter', 'AllHostsFilter' )) }}
 
 quota_instances=100

--- a/openstack/nova/files/kilo.nova.conf
+++ b/openstack/nova/files/kilo.nova.conf
@@ -50,6 +50,7 @@ vncserver_proxyclient_address = {{  salt['pillar.get']('virl:static_ip', salt['g
 novncproxy_port = {{ salt['pillar.get']('virl:vnc_port', salt['grains.get']('vnc_port', 19407)) }}
 novncproxy_base_url = http://127.0.1.1:{{ salt['pillar.get']('virl:vnc_port', salt['grains.get']('vnc_port', '19407')) }}/vnc_auto.html
 
+ram_allocation_ratio = 5.0
 scheduler_default_filters= {{  salt['pillar.get']('virl:nova_filter', salt['grains.get']('nova_filter', 'AllHostsFilter' )) }}
 
 quota_instances=100

--- a/openstack/nova/files/mitaka.nova.conf
+++ b/openstack/nova/files/mitaka.nova.conf
@@ -52,6 +52,7 @@ vncserver_proxyclient_address = {{ virl.int_ip }}
 novncproxy_port = {{ salt['pillar.get']('virl:vnc_port', salt['grains.get']('vnc_port', 19407)) }}
 novncproxy_base_url = http://127.0.1.1:{{ salt['pillar.get']('virl:vnc_port', salt['grains.get']('vnc_port', '19407')) }}/vnc_auto.html
 
+ram_allocation_ratio = 5.0
 scheduler_default_filters= {{  salt['pillar.get']('virl:nova_filter', salt['grains.get']('nova_filter', 'AllHostsFilter' )) }}
 
 {% if not virl.cluster %}

--- a/openstack/nova/files/nova.conf
+++ b/openstack/nova/files/nova.conf
@@ -42,6 +42,7 @@ vncserver_listen = {{  salt['pillar.get']('virl:static_ip', salt['grains.get']('
 vncserver_proxyclient_address = {{  salt['pillar.get']('virl:static_ip', salt['grains.get']('static_ip', '127.0.0.1' )) }}
 novncproxy_port = {{ salt['pillar.get']('virl:vnc_port', salt['grains.get']('vnc_port', '19407')) }}
 novncproxy_base_url = http://127.0.1.1:{{ salt['pillar.get']('virl:vnc_port', salt['grains.get']('vnc_port', '19407')) }}/vnc_auto.html
+ram_allocation_ratio = 5.0
 scheduler_default_filters= {{  salt['pillar.get']('virl:nova_filter', salt['grains.get']('nova_filter', 'AllHostsFilter' )) }}
 serial_port_proxyclient_address = 0.0.0.0
 serialproxy_port = {{ salt['pillar.get']('virl:serial_port', salt['grains.get']('serial_port', '19406')) }}

--- a/openstack/nova/install.sls
+++ b/openstack/nova/install.sls
@@ -91,7 +91,7 @@ compute filter for cluster:
     - filename: /etc/nova/nova.conf
     - section: 'DEFAULT'
     - parameter: 'scheduler_default_filters'
-    - value: 'AllHostsFilter,ComputeFilter'
+    - value: 'RamFilter,AllHostsFilter,ComputeFilter'
     - require:
       - file: /etc/nova/nova.conf
 


### PR DESCRIPTION
Smaller compute hosts get their memory overloaded and around 4x memory size cause premature launch stop and node errors.