### PR TITLE
Set nova's URL to glance on all computes

### DIFF
--- a/openstack/nova/files/compute.nova.conf
+++ b/openstack/nova/files/compute.nova.conf
@@ -136,8 +136,7 @@ redis_port = 6379
 {% if virl.mitaka %}
 [workarounds]
 disable_libvirt_livesnapshot = False
+{% endif %}
 
 [glance]
 api_servers = http://{{ virl.controller_ip }}:9292
-
-{% endif %}


### PR DESCRIPTION
Some guy was repeatedly missing this config in kilo.