### PR TITLE
Enable all current bridges for NTP in case time server is reached ove…

### DIFF
--- a/virl/files/ntp.conf
+++ b/virl/files/ntp.conf
@@ -54,6 +54,10 @@ interface ignore wildcard
 interface listen {{ virl.publicport }}
 interface listen lo
 interface listen lo0
+interface listen br1
+interface listen br2
+interface listen br3
+interface listen br4
 {% if virl.controller %}
 interface listen {{ virl.controller_ip }}/{{ virl.int_prefixlen }}
 {% else %}


### PR DESCRIPTION
…r them

@Snergster has some boxes which have dummied public_port and uses the flat network for everything, including time server access.